### PR TITLE
Remove node-fetch in favor of node's builtin fetch module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,23 @@
 {
   "name": "quickbooks-node-promise",
-  "version": "3.3.14",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quickbooks-node-promise",
-      "version": "3.3.14",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "csrf": "^3.1.0",
         "form-data": "^4.0.0",
         "jsonwebtoken": "^9.0.2",
-        "node-fetch": "^2.7.0",
         "qs": "^6.11.2",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.19",
         "@types/jsonwebtoken": "^9.0.3",
-        "@types/node-fetch": "^2.6.6",
         "@types/uuid": "^9.0.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -2475,16 +2473,6 @@
         "undici-types": "~5.25.1"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/@types/qs": {
       "version": "6.9.8",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
@@ -3700,6 +3688,27 @@
       "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/cross-spawn": {
@@ -6588,25 +6597,6 @@
         "node": ">= 0.10.5"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -8680,7 +8670,9 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-migrate": {
       "version": "0.1.35",
@@ -9430,12 +9422,16 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -11404,16 +11400,6 @@
         "undici-types": "~5.25.1"
       }
     },
-    "@types/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
     "@types/qs": {
       "version": "6.9.8",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
@@ -12329,6 +12315,17 @@
       "dev": true,
       "requires": {
         "node-fetch": "^2.6.12"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -14574,14 +14571,6 @@
         "minimatch": "^3.0.2"
       }
     },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -16188,7 +16177,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "ts-migrate": {
       "version": "0.1.35",
@@ -16743,12 +16733,14 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "git+https://github.com/pbrink231/quickbooks-node-promise.git"
   },
+  "engines": {
+    "node": ">=21"
+  },
   "dependencies": {
     "csrf": "^3.1.0",
     "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickbooks-node-promise",
-  "version": "3.3.14",
+  "version": "4.0.0",
   "description": "Connect to QuickBooks Online API with OAuth 2 with typescript on entities",
   "author": "Peter Brink",
   "license": "ISC",
@@ -23,14 +23,12 @@
     "csrf": "^3.1.0",
     "form-data": "^4.0.0",
     "jsonwebtoken": "^9.0.2",
-    "node-fetch": "^2.7.0",
     "qs": "^6.11.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.19",
     "@types/jsonwebtoken": "^9.0.3",
-    "@types/node-fetch": "^2.6.6",
     "@types/uuid": "^9.0.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@
 import { v4 as uuidv4 } from "uuid";
 import qs from "qs";
 import jwt from "jsonwebtoken";
-import fetch, { Response, RequestInit } from "node-fetch";
 import FormData from "form-data";
 import Tokens from "csrf";
 import crypto from "crypto";
@@ -665,7 +664,7 @@ class Quickbooks {
     if (!response.ok) {
       throw new QBFetchError(response.statusText, response);
     }
-    const newTokenData: TokenData = await response.json();
+    const newTokenData: TokenData = await response.json() as TokenData;
     return this.saveToken(newTokenData);
   };
 
@@ -786,7 +785,7 @@ class Quickbooks {
     if (!response.ok) {
       throw new QBFetchError(response.statusText, response);
     }
-    const newTokenData: TokenData = await response.json();
+    const newTokenData: TokenData = await response.json() as TokenData;
     return this.saveToken(newTokenData);
 
   }
@@ -895,7 +894,7 @@ class Quickbooks {
     return fetch(Quickbooks.JWKS_URL, fetchOptions)
       .then((response) => {
         if (response.ok) {
-          return response.json();
+          return response.json() as Promise<{ keys: { kid: string, n: string, e: string }[] }>;
         } else {
           throw new QBFetchError(response.statusText, response);
         }
@@ -1016,7 +1015,7 @@ class Quickbooks {
     const fetchOptions: RequestInit = {
       method: verb,
       headers: opts.headers,
-      body: opts.body,
+      body: opts.body as BodyInit,
     };
     url = `${url}?${qs.stringify(opts.qs)}`;
 
@@ -1027,8 +1026,7 @@ class Quickbooks {
 
     const response = await fetch(url, fetchOptions);
     if (response.ok) {
-
-      const returnedObject: T = await response.json();
+      const returnedObject: T = await response.json() as T;
       if (opts.returnHeadersInBody) {
         const specialHeaders: HeaderAdditions['specialHeaders'] = {
           intuitTid: response.headers.get("intuit_tid"),
@@ -1042,7 +1040,7 @@ class Quickbooks {
       return returnedObject;
     } else {
       try {
-        const body = await response.json();
+        const body = await response.json() as ResponseErrorJson & { Fault: { Error: boolean, type: string } };
         if (body?.Fault?.Error) {
           throw new QBResponseError(`Error of type ${body.Fault.type}`, body);
         }
@@ -1083,7 +1081,8 @@ class Quickbooks {
 
     const response = await fetch(sendUrl, fetchOptions);
     if (response.ok) {
-      return response.buffer();
+      const arrayBuffer = await response.arrayBuffer();
+      return Buffer.from(arrayBuffer);
     } else {
       throw new QBFetchError(response.statusText, response);
     }


### PR DESCRIPTION
> [!IMPORTANT]
> I'm updating the package version to the major version 4.0, as this change makes the package incompatible with node versions earlier than v21 (node v21 would be the first compatible version)

Given node v21 was released with a stable builtin fetch in October 2023 ([reference](https://nodejs.org/en/blog/announcements/v21-release-announce#stable-fetchwebstreams)), we can stop relying on node-fetch and use the builtin instead.

This change fixes the issue I described in #30