### PR TITLE
Fix void operation for Payment entity and fix Purchase EntityRef type

### DIFF
--- a/quickbooks-type-scrape/processFixes.ts
+++ b/quickbooks-type-scrape/processFixes.ts
@@ -80,6 +80,19 @@ export const typeAttributeFixes: {
       },
     },
   },
+  Purchase: {
+    attributeReplacements: {
+      EntityRef: {
+        replacedInterface: `${indent}/**
+  ${indent} * META: Optional
+  ${indent} *
+  ${indent} * DESCRIPTION: Specifies the party with whom an expense is associated. Can be **Customer**, **Vendor, or Employee.**
+  ${indent} * Query the corresponding name list resource of the associated type to determine the appropriate object for this reference. Use the **Id** and **DisplayName** values from that object for **EntityRef.value** and **EntityRef.name**, respectively. Set **EntityRef.type** to the type of object associated with this expense. For example, if this object represents a purchase from a vendor, then set **EntityRef.type** to **Vendor** and query the Vendor resource for the appropriate object to reference.
+  ${indent} */
+  ${indent}EntityRef?: { value: string, name?: string, type?: "Customer" | "Vendor" | "Employee" };\n`,
+      },
+    }
+  }
 };
 
 export const typeConversion: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1161,7 +1161,10 @@ class Quickbooks {
     // requires minimum Id and SyncToken
     // if passed Id as numeric value then grab entity and send it to delete
     const url = "/" + entityName.toLowerCase();
-    let qs = { operation: "void" };
+    let qs: { operation: string; include?: string } = { operation: "void" };
+    if (entityName === EntityName.Payment) {
+      qs = { operation: "update", include: "void" };
+    }
     if (typeof idOrEntity === 'object') {
       return this.request<{
         [P in keyof (BaseRequest & HeaderAdditions &
@@ -2502,7 +2505,7 @@ class Quickbooks {
     if (typeof payment === "object") {
       payment.sparse = true;
     }
-    return this.update(EntityName.Payment, payment);
+    return this.void(EntityName.Payment, payment);
   };
 
   /**

--- a/src/qbTypes.ts
+++ b/src/qbTypes.ts
@@ -6272,12 +6272,12 @@ export interface Purchase {
    */
   DepartmentRef?: ReferenceType;
   /**
-   * META: Optional
-   *
-   * DESCRIPTION: Specifies the party with whom an expense is associated. Can be **Customer**, **Vendor, or Employee.**
-   * Query the corresponding name list resource of the associated type to determine the appropriate object for this reference. Use the **Id** and **DisplayName** values from that object for **EntityRef.value** and **EntityRef.name**, respectively. Set **EntityRef.type** to the type of object associated with this expense. For example, if this object represents a purchase from a vendor, then set **EntityRef.type** to **Vendor** and query the Vendor resource for the appropriate object to reference.
-   */
-  EntityRef?: ReferenceType;
+     * META: Optional
+     *
+     * DESCRIPTION: Specifies the party with whom an expense is associated. Can be **Customer**, **Vendor, or Employee.**
+     * Query the corresponding name list resource of the associated type to determine the appropriate object for this reference. Use the **Id** and **DisplayName** values from that object for **EntityRef.value** and **EntityRef.name**, respectively. Set **EntityRef.type** to the type of object associated with this expense. For example, if this object represents a purchase from a vendor, then set **EntityRef.type** to **Vendor** and query the Vendor resource for the appropriate object to reference.
+     */
+    EntityRef?: { value: string, name?: string, type?: "Customer" | "Vendor" | "Employee" };
   /**
    * META: Optional ,minorVersion: 40 ,
    *


### PR DESCRIPTION
Updated `voidPayment()` to include the `include=void` query param — the Payment entity requires `?operation=update&include=void` to properly void via the QuickBooks API.

Updated processFixes to change `Purchase.EntityRef` type from the generic `ReferenceType` to:
```
EntityRef: { 
  value: string, 
  name?: string, 
  type?: "Customer" | "Vendor" | "Employee" 
}
``` 
so it matches the QuickBooks API spec.

Fixes #32 and #33 